### PR TITLE
Leave binaries in LIBRARY_BIN

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,7 +11,3 @@ if errorlevel 1 exit 1
 
 nmake install
 if errorlevel 1 exit 1
-
-mkdir %SCRIPTS%
-move %LIBRARY_BIN%\xmlwf.exe %SCRIPTS%\xmlwf.exe || exit 1
-move %LIBRARY_BIN%\expat.dll %SCRIPTS%\expat.dll || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: dd7dab7a5fea97d2a6a43f511449b7cd
 
 build:
-    number: 1
+    number: 2
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]


### PR DESCRIPTION
Is there any reason why the binaries are moved into the `Scripts` folder at the moment? This seems inconsistent with other packages and a bit confusing. Perhaps it is left over from the distant past?

This PR leaves them where they are installed by default. `gdal` seems fine with this. Let me know if there is other stuff that needs considering.